### PR TITLE
refactor: move comment lib script location to head tag

### DIFF
--- a/src/main/java/run/halo/comment/widget/CommentWidgetHeadProcessor.java
+++ b/src/main/java/run/halo/comment/widget/CommentWidgetHeadProcessor.java
@@ -1,0 +1,44 @@
+package run.halo.comment.widget;
+
+import lombok.RequiredArgsConstructor;
+import org.pf4j.PluginWrapper;
+import org.springframework.stereotype.Component;
+import org.springframework.util.PropertyPlaceholderHelper;
+import org.thymeleaf.context.ITemplateContext;
+import org.thymeleaf.model.IModel;
+import org.thymeleaf.model.IModelFactory;
+import org.thymeleaf.processor.element.IElementModelStructureHandler;
+import reactor.core.publisher.Mono;
+import run.halo.app.theme.dialect.TemplateHeadProcessor;
+
+import java.util.Properties;
+
+@Component
+@RequiredArgsConstructor
+public class CommentWidgetHeadProcessor implements TemplateHeadProcessor {
+
+    static final PropertyPlaceholderHelper PROPERTY_PLACEHOLDER_HELPER = new PropertyPlaceholderHelper("${", "}");
+
+    private final PluginWrapper pluginWrapper;
+
+    @Override
+    public Mono<Void> process(ITemplateContext context, IModel model,
+                              IElementModelStructureHandler structureHandler) {
+        final IModelFactory modelFactory = context.getModelFactory();
+        model.add(modelFactory.createText(commentWidgetScript()));
+        return Mono.empty();
+    }
+
+    private String commentWidgetScript() {
+
+        final Properties properties = new Properties();
+        properties.setProperty("version", pluginWrapper.getDescriptor().getVersion());
+
+        return PROPERTY_PLACEHOLDER_HELPER.replacePlaceholders("""
+                <!-- plugin-comment-widget start -->
+                <script src="/plugins/PluginCommentWidget/assets/static/comment-widget.iife.js?version=${version}"></script>
+                <link rel="stylesheet" href="/plugins/PluginCommentWidget/assets/static/style.css?version=${version}" />
+                <!-- plugin-comment-widget end -->
+                """, properties);
+    }
+}

--- a/src/main/java/run/halo/comment/widget/DefaultCommentWidget.java
+++ b/src/main/java/run/halo/comment/widget/DefaultCommentWidget.java
@@ -65,8 +65,6 @@ public class DefaultCommentWidget implements CommentWidget {
 
         return PROPERTY_PLACEHOLDER_HELPER.replacePlaceholders("""
                 <div id="${domId}"></div>
-                <script src="/plugins/PluginCommentWidget/assets/static/comment-widget.iife.js?version=${version}"></script>
-                <link rel="stylesheet" href="/plugins/PluginCommentWidget/assets/static/style.css?version=${version}" />
                 <script>
                   CommentWidget.init(
                     "#${domId}",


### PR DESCRIPTION
将 script 移动至 head 标签，以解决主题使用 pjax 或者同页面多评论组件（瞬间）的问题。

Fixes #86 

```release-note
全局加载评论组件，解决部分主题使用 pjax 库之后的评论组件加载问题。
```