### PR TITLE
Fix the issue of scrolling to the comment view after the initial loading of comments

### DIFF
--- a/packages/comment-widget/src/comment-widget.ts
+++ b/packages/comment-widget/src/comment-widget.ts
@@ -84,7 +84,9 @@ export class CommentWidget extends LitElement {
 
   override render() {
     return html`<div class="comment-widget">
-      <comment-form @reload="${() => this.fetchComments(1)}"></comment-form>
+      <comment-form
+        @reload="${() => this.fetchComments({ page: 1, scrollIntoView: true })}"
+      ></comment-form>
       ${this.loading
         ? html`<loading-block></loading-block>`
         : html`
@@ -135,7 +137,8 @@ export class CommentWidget extends LitElement {
     this.currentUser = data.user.metadata.name === 'anonymousUser' ? undefined : data.user;
   }
 
-  async fetchComments(page?: number) {
+  async fetchComments(options?: { page?: number; scrollIntoView?: boolean }) {
+    const { page, scrollIntoView } = options || {};
     try {
       if (this.comments.items.length === 0) {
         this.loading = true;
@@ -170,14 +173,17 @@ export class CommentWidget extends LitElement {
       }
     } finally {
       this.loading = false;
-      this.scrollIntoView({ block: 'start', inline: 'start', behavior: 'smooth' });
+
+      if (scrollIntoView) {
+        this.scrollIntoView({ block: 'start', inline: 'start', behavior: 'smooth' });
+      }
     }
   }
 
   async onPageChange(e: CustomEvent) {
     const data = e.detail;
     this.comments.page = data.page;
-    await this.fetchComments();
+    await this.fetchComments({ scrollIntoView: true });
   }
 
   override connectedCallback(): void {


### PR DESCRIPTION
调整滚动到评论组件视图的时机，改为仅在分页的时候才滚动到顶部。在此之前，如果文章比较短，可以在屏幕中显示评论组件时，页面可能会自动滚动到评论组件的部分。

/kind bug

```release-note
优化加载数据之后滚动到评论组件视图的时机
```