### PR TITLE
fix: issue of the emoji picker being semi-transparent

### DIFF
--- a/packages/comment-widget/src/emoji-button.ts
+++ b/packages/comment-widget/src/emoji-button.ts
@@ -118,7 +118,7 @@ export class EmojiButton extends LitElement {
         position: relative;
       }
 
-      .emoji-button:hover {
+      .emoji-button:hover icon-emoji {
         opacity: 0.8;
       }
 


### PR DESCRIPTION
修复鼠标移动到 Emoji 区域背景变半透明的问题。

Fixes https://github.com/halo-dev/plugin-comment-widget/issues/96

```release-note
修复鼠标移动到 Emoji 区域背景变半透明的问题。
```