### PR TITLE
chore: change version to release 2.1.0

### DIFF
--- a/packages/comment-widget/package.json
+++ b/packages/comment-widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halo-dev/comment-widget",
-  "version": "1.3.0",
+  "version": "2.1.0",
   "author": {
     "name": "Halo",
     "url": "https://github.com/halo-dev"


### PR DESCRIPTION
修改组件核心包的版本号，准备发布 2.1.0 版本。

> 在此之前，发布插件版本的时候并没有发布组件包，从这个版本开始，将同步推送到 npmjs。

```release-note
None
```