### PR TITLE
头像服务增强：增加一些国内常用的头像服务商

### DIFF
--- a/packages/comment-widget/src/avatar/providers/cravatar.ts
+++ b/packages/comment-widget/src/avatar/providers/cravatar.ts
@@ -1,0 +1,9 @@
+import AvatarProvider from './avatar-provider';
+
+class Cravatar extends AvatarProvider {
+    override getAvatarSrc(emailHash: string | undefined): string {
+        return `${this.url}/avatar/${emailHash}`;
+    }
+}
+
+export default new Cravatar('Cravatar', 'https://cravatar.cn');

--- a/packages/comment-widget/src/avatar/providers/index.ts
+++ b/packages/comment-widget/src/avatar/providers/index.ts
@@ -1,10 +1,14 @@
 import Gravatar from './gravatar';
+import Cravatar from './cravatar';
+import Weavatar from "./weavatar";
 import AvatarProvider from './avatar-provider';
 
 let avatarProvider: AvatarProvider | undefined;
 
 enum AvatarProviderEnum {
   GRAVATAR = 'gravatar',
+  CRAVATAR = 'cravatar',
+  WEAVATAR = 'weavatar'
 }
 
 export function setAvatarProvider(provider: string, mirrorUrl?: string) {
@@ -14,6 +18,18 @@ export function setAvatarProvider(provider: string, mirrorUrl?: string) {
         Gravatar.url = mirrorUrl;
       }
       avatarProvider = Gravatar;
+      break;
+    case AvatarProviderEnum.CRAVATAR:
+      if (mirrorUrl) {
+        Cravatar.url = mirrorUrl;
+      }
+      avatarProvider = Cravatar;
+      break;
+    case AvatarProviderEnum.WEAVATAR:
+      if(mirrorUrl){
+        Weavatar.url = mirrorUrl;
+      }
+      avatarProvider = Weavatar;
       break;
     default:
   }

--- a/packages/comment-widget/src/avatar/providers/weavatar.ts
+++ b/packages/comment-widget/src/avatar/providers/weavatar.ts
@@ -1,0 +1,9 @@
+import AvatarProvider from './avatar-provider';
+
+class Weavatar extends AvatarProvider {
+    override getAvatarSrc(emailHash: string | undefined): string {
+        return `${this.url}/avatar/${emailHash}`;
+    }
+}
+
+export default new Weavatar('Weavatar', 'https://weavatar.com');

--- a/src/main/resources/extensions/settings.yaml
+++ b/src/main/resources/extensions/settings.yaml
@@ -73,6 +73,10 @@ spec:
           options:
             - label: "Gravatar"
               value: "gravatar"
+            - label: "Cravatar"
+              value: "cravatar"
+            - label: "Weavatar"
+              value: "weavatar"
           value: "gravatar"
         - $formkit: text
           label: 头像服务镜像地址


### PR DESCRIPTION
按照已有头像服务的示例，对头像服务源进行增加。

此外我看了下 `AvatarProvider` 这个类，只有头像服务源名称和服务地址，没有一些参数配置，比如用户想要配置头像源的默认头像以及图片大小还有其他参数，是否可以在 `AvatarProvider` 这个类中新加一个参数 _params 让用户自己配置一些头像源请求的参数？如有必要，我在重新修改代码，再次提交代码