### PR TITLE
Fix Input font-size causes iOS zoom issue on focus

### DIFF
--- a/packages/comment-widget/src/comment-editor.ts
+++ b/packages/comment-widget/src/comment-editor.ts
@@ -238,6 +238,7 @@ export class CommentEditor extends LitElement {
       .tiptap {
         outline: none;
         border: none;
+        font-size: 16px;
       }
 
       .tiptap p {

--- a/packages/comment-widget/uno.config.ts
+++ b/packages/comment-widget/uno.config.ts
@@ -56,7 +56,7 @@ export default defineConfig({
   ],
   shortcuts: {
     input:
-      'px-3 py-0 text-sm rounded-base bg-transparent border h-12 border-muted-1 border-solid outline-none transition-all focus:border-primary-1 focus:shadow-input placeholder:text-text-3',
+      'px-3 py-0 text-[16px] rounded-base bg-transparent border h-12 border-muted-1 border-solid outline-none transition-all focus:border-primary-1 focus:shadow-input placeholder:text-text-3',
     'icon-button': 'inline-flex items-center gap-[0.1em] cursor-pointer',
     'icon-button-icon':
       'inline-flex items-center justify-center rounded-full transition-all duration-150 p-2 text-text-3 group-hover:bg-muted-3 group-hover:text-text-1',


### PR DESCRIPTION
On iOS devices, inputs with font-size smaller than trigger automatic zoom when focused. 