### PR TITLE
feat: support custom avatar providers

### DIFF
--- a/packages/comment-widget/src/avatar/providers/custom.ts
+++ b/packages/comment-widget/src/avatar/providers/custom.ts
@@ -1,0 +1,22 @@
+import AvatarProvider from './avatar-provider';
+
+const seedPlaceholderPattern = /\{(?:hash|seed)\}/;
+
+class CustomAvatar extends AvatarProvider {
+  override getAvatarSrc(emailHash: string | undefined): string {
+    const source = this.url.trim();
+    const seed = encodeURIComponent(emailHash || 'anonymous');
+
+    if (!source) {
+      return '';
+    }
+
+    if (seedPlaceholderPattern.test(source)) {
+      return source.replace(/\{hash\}/g, seed).replace(/\{seed\}/g, seed);
+    }
+
+    return `${source}${source.includes('?') ? '&' : '?'}_avatar=${seed}`;
+  }
+}
+
+export default new CustomAvatar('Custom', '');

--- a/packages/comment-widget/src/avatar/providers/index.ts
+++ b/packages/comment-widget/src/avatar/providers/index.ts
@@ -1,14 +1,20 @@
 import type AvatarProvider from './avatar-provider';
+import Custom from './custom';
 import Gravatar from './gravatar';
 
 let avatarProvider: AvatarProvider | undefined;
 
 enum AvatarProviderEnum {
+  CUSTOM = 'custom',
   GRAVATAR = 'gravatar',
 }
 
 export function setAvatarProvider(provider: string, mirrorUrl?: string) {
   switch (provider) {
+    case AvatarProviderEnum.CUSTOM:
+      Custom.url = mirrorUrl || '';
+      avatarProvider = Custom;
+      break;
     case AvatarProviderEnum.GRAVATAR:
       if (mirrorUrl) {
         Gravatar.url = mirrorUrl;

--- a/packages/comment-widget/src/types/index.ts
+++ b/packages/comment-widget/src/types/index.ts
@@ -25,7 +25,7 @@ interface SecurityConfig {
 }
 
 interface AvatarConfig {
-  provider: 'gravatar';
+  provider: 'custom' | 'gravatar';
   enable: boolean;
   providerMirror: string;
   policy: 'anonymousUser' | 'allUser' | 'noAvatarUser';

--- a/src/main/resources/extensions/settings.yaml
+++ b/src/main/resources/extensions/settings.yaml
@@ -120,6 +120,8 @@ spec:
           if: "$get(enable).value === true"
           name: provider
           options:
+            - label: "自定义头像服务"
+              value: "custom"
             - label: "Gravatar"
               value: "gravatar"
           value: "gravatar"
@@ -128,7 +130,7 @@ spec:
           if: "$get(enable).value === true"
           name: providerMirror
           value: ""
-          help: 使用官方源则留空, 示例：https://gravatar.com
+          help: 自定义头像服务支持 {hash} 或 {seed} 占位符；不填写占位符时会自动追加 _avatar 参数。Gravatar 示例：https://gravatar.com
         - $formkit: select
           label: 头像策略
           if: "$get(enable).value === true"


### PR DESCRIPTION
## 背景

部分站点希望匿名评论使用自定义头像服务，例如随机头像接口或站点自建头像服务，同时保留已登录用户的真实头像。当前插件只有 Gravatar provider，且Dicebear头像插件对于大部分用户网络不是很友好，不太 
稳定，无法灵活配置这类匿名头像服务。新增自定义匿名头像服务提供者，用于解决当前评论组件仅支持 Gravatar 的限制。

## 具体实现

- 新增 `custom` 头像 provider。
- 后台头像服务提供者新增“自定义头像服务”选项。
- 自定义头像服务支持 `{hash}` / `{seed}` 占位符。
- 如果 URL 中没有占位符，会自动追加 `_avatar={hash}` 参数，便于头像服务按匿名用户稳定生成头像。
- 保留原有 Gravatar provider。
- 默认配置保持保守：不默认启用第三方头像，默认 provider 仍为 Gravatar。
- 默认策略仍为 `anonymousUser`，即仅匿名评论使用第三方头像服务，不影响已登录用户真实头像。
