### PR TITLE
feat: add emoji picker setting

### DIFF
--- a/packages/comment-widget/src/base-form.ts
+++ b/packages/comment-widget/src/base-form.ts
@@ -195,7 +195,7 @@ export class BaseForm extends LitElement {
   override render() {
     return html`
       <form class="form w-full flex flex-col gap-4" @submit="${this.onSubmit}">
-        <comment-editor ${ref(this.editorRef)} .placeholder=${this.configMapData?.editor?.placeholder}></comment-editor>
+        <comment-editor .enableEmoji=${this.configMapData?.editor?.enableEmoji !== false} ${ref(this.editorRef)} .placeholder=${this.configMapData?.editor?.placeholder}></comment-editor>
 
         ${when(
           !this.currentUser && this.allowAnonymousComments,

--- a/packages/comment-widget/src/comment-editor.ts
+++ b/packages/comment-widget/src/comment-editor.ts
@@ -82,6 +82,9 @@ export class CommentEditor extends LitElement {
   @property({ type: Boolean, attribute: 'keep-alive' })
   keepAlive = false;
 
+  @property({ type: Boolean })
+  enableEmoji = true;
+
   @state()
   editor: Editor | undefined;
 
@@ -190,10 +193,15 @@ export class CommentEditor extends LitElement {
           ${repeat(actionItems, (item) =>
             this.renderActionItem(item, this.editor)
           )}
-          ${this.renderActionItem({ type: 'separator' })}
-          <li class="flex items-center">
-            <emoji-button @emoji-select=${this.onEmojiSelect}></emoji-button>
-          </li>
+          ${when(
+            this.enableEmoji,
+            () => html`
+            ${this.renderActionItem({ type: 'separator' })}
+            <li class="flex items-center">
+              <emoji-button @emoji-select=${this.onEmojiSelect}></emoji-button>
+            </li>
+          `
+          )}
         </ul>
       </div>`;
   }

--- a/packages/comment-widget/src/types/index.ts
+++ b/packages/comment-widget/src/types/index.ts
@@ -32,6 +32,7 @@ interface AvatarConfig {
 }
 
 interface EditorConfig {
+  enableEmoji?: boolean;
   placeholder?: string;
 }
 

--- a/src/main/resources/extensions/settings.yaml
+++ b/src/main/resources/extensions/settings.yaml
@@ -152,6 +152,11 @@ spec:
     - group: editor
       label: 编辑器
       formSchema:
+        - $formkit: checkbox
+          name: enableEmoji
+          label: 启用表情选择器
+          help: 控制评论和回复输入框中的表情按钮，不影响已有评论中的表情
+          value: true
         - $formkit: text
           name: placeholder
           label: 自定义评论框占位符


### PR DESCRIPTION
#### What this PR does / why we need it:

新增默认开启的“启用表情选择器”设置，同时控制评论和回复输入框中的表情按钮。关闭时一并隐藏对应分隔线，不影响已有评论中的表情；未配置该选项的站点保持原有行为。

#### Which issue(s) this PR fixes:

Fixes #138

#### Does this PR introduce a user-facing change?
```release-note
支持开启或关闭评论和回复输入框中的表情选择器。
```
