### PR TITLE
feat: keep one reply editor open per comment list

### DIFF
--- a/packages/comment-widget/src/comment-item.ts
+++ b/packages/comment-widget/src/comment-item.ts
@@ -96,11 +96,12 @@ export class CommentItem extends LitElement {
   }
 
   handleShowReplies() {
-    this.showReplies = !this.showReplies;
-
     if (!this.configMapData?.basic.withReplies) {
-      this.showReplyForm = !this.showReplyForm;
+      this.handleToggleReplyForm();
+      this.showReplies = this.showReplyForm;
+      return;
     }
+    this.showReplies = !this.showReplies;
   }
 
   onReplyCreated() {
@@ -108,8 +109,23 @@ export class CommentItem extends LitElement {
     this.showReplies = true;
   }
 
+  closeReplyForm() {
+    this.showReplyForm = false;
+  }
+
   handleToggleReplyForm() {
-    this.showReplyForm = !this.showReplyForm;
+    if (this.showReplyForm) {
+      this.closeReplyForm();
+      return;
+    }
+    this.showReplyForm = true;
+    this.dispatchEvent(
+      new CustomEvent('reply-form-open', {
+        detail: this,
+        bubbles: true,
+        composed: true,
+      })
+    );
   }
 
   override render() {

--- a/packages/comment-widget/src/comment-list.ts
+++ b/packages/comment-widget/src/comment-list.ts
@@ -69,6 +69,23 @@ export class CommentList extends LitElement {
   @state()
   loading = false;
 
+  private activeReplyItem?: { closeReplyForm(): void };
+
+  private onReplyFormOpen(event: CustomEvent<{ closeReplyForm(): void }>) {
+    event.stopPropagation();
+    if (this.activeReplyItem === event.detail) {
+      return;
+    }
+    this.activeReplyItem?.closeReplyForm();
+    this.activeReplyItem = event.detail;
+  }
+
+  override disconnectedCallback(): void {
+    this.activeReplyItem?.closeReplyForm();
+    this.activeReplyItem = undefined;
+    super.disconnectedCallback();
+  }
+
   get shouldDisplayPagination() {
     if (this.loading) {
       return false;
@@ -155,7 +172,7 @@ export class CommentList extends LitElement {
               <span>${msg(html`${this.comments.total} Comments`)}</span>
             </div>
 
-            <div class="comment-list">
+            <div class="comment-list" @reply-form-open=${this.onReplyFormOpen}>
               ${repeat(
                 this.comments.items,
                 (item) => item.metadata.name,

--- a/packages/comment-widget/src/reply-item.ts
+++ b/packages/comment-widget/src/reply-item.ts
@@ -78,8 +78,23 @@ export class ReplyItem extends LitElement {
     }
   }
 
+  closeReplyForm() {
+    this.showReplyForm = false;
+  }
+
   handleToggleReplyForm() {
-    this.showReplyForm = !this.showReplyForm;
+    if (this.showReplyForm) {
+      this.closeReplyForm();
+      return;
+    }
+    this.showReplyForm = true;
+    this.dispatchEvent(
+      new CustomEvent('reply-form-open', {
+        detail: this,
+        bubbles: true,
+        composed: true,
+      })
+    );
   }
 
   async handleUpvote() {


### PR DESCRIPTION
#### What this PR does / why we need it:

同一评论列表内打开新的回复框时，关闭并清空之前的回复框，支持评论与楼中楼之间切换。已展开的回复列表保持不变，同页多个评论组件独立处理。

#### Which issue(s) this PR fixes:

Fixes #92

#### Does this PR introduce a user-facing change?
```release-note
同一评论列表仅保留一个回复框，切换回复对象时自动关闭并清空之前的输入内容。
```
